### PR TITLE
fix sequential test failing on min-deps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # dolphin
+[![Pytest and build docker image](https://github.com/opera-adt/dolphin/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/opera-adt/dolphin/actions/workflows/tests.yml)
 
 High resolution wrapped phase estimation for InSAR using combined PS/DS processing.
 

--- a/src/dolphin/sequential.py
+++ b/src/dolphin/sequential.py
@@ -9,6 +9,7 @@ References
 import warnings
 from collections import defaultdict
 from math import nan
+from os import fspath
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -295,7 +296,7 @@ def run_evd_sequential(
     gdal_calc.Calc(
         NoDataValue=nan,
         format="GTiff",
-        outfile=output_tcorr_file,
+        outfile=fspath(output_tcorr_file),
         type="Float32",
         quiet=True,
         overwrite=True,
@@ -333,7 +334,7 @@ def compress(
     # Avoid divide by zero (there may be 0s at the upsampled boundary)
     mle_norm[mle_norm == 0] = np.nan
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="invalid value encountered in divide")
+        warnings.filterwarnings("ignore", message="invalid value encountered")
         return (
             np.nansum(slc_stack * np.conjugate(mle_estimate_upsampled), axis=0)
             / mle_norm

--- a/tests/test_ps.py
+++ b/tests/test_ps.py
@@ -9,7 +9,7 @@ def test_ps_block(slc_stack):
     # Run the PS selector on entire stack
     amp_mean, amp_disp, ps_pixels = dolphin.ps.calc_ps_block(
         np.abs(slc_stack),
-        amp_dispersion_threshold=0.35,  # should be too low for random data
+        amp_dispersion_threshold=0.25,  # should be too low for random data
     )
     assert amp_mean.shape == amp_disp.shape == ps_pixels.shape
     assert amp_mean.dtype == amp_disp.dtype == np.float32
@@ -27,7 +27,7 @@ def test_ps_nodata(slc_stack):
     # Run the PS selector on entire stack
     amp_mean, amp_disp, ps_pixels = dolphin.ps.calc_ps_block(
         np.abs(s_nan),
-        amp_dispersion_threshold=0.35,
+        amp_dispersion_threshold=0.95,  # high thresh shouldn't matter for nodata
     )
     assert amp_mean[0, 0] == 0
     assert amp_disp[0, 0] == 0


### PR DESCRIPTION
https://github.com/opera-adt/dolphin/actions/runs/4019914684/jobs/6907299026

older gdal_calc seems to be unable to accept the Path as outfile

the numpy warning used to be true_divide. so make the regex less specific