### PR TITLE
Ps fill fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,5 @@ ignore_missing_imports = true
 ignore = "D100,D102,D104,D105,D106,D107,D203,D204,D213,D413"
 
 [tool.pytest.ini_options]
-addopts = "  --cov=dolphin --dist each -n auto --maxprocesses=8 --doctest-modules --ignore=scripts --ignore=docs --ignore=data"
+addopts = "  --cov=dolphin  -n auto --maxprocesses=8 --doctest-modules --ignore=scripts --ignore=docs --ignore=data"
 filterwarnings = ["error"]

--- a/src/dolphin/phase_link/covariance.py
+++ b/src/dolphin/phase_link/covariance.py
@@ -94,7 +94,7 @@ def coh_mat_single(neighbor_stack, cov_mat=None):
     """Given a (n_slc, n_samps) samples, estimate the coherence matrix."""
     nslc = neighbor_stack.shape[0]
     if cov_mat is None:
-        cov_mat = np.zeros((nslc, nslc), dtype="complex64")
+        cov_mat = np.zeros((nslc, nslc), dtype=neighbor_stack.dtype)
 
     for ti in range(nslc):
         # Start with the diagonal equal to 1

--- a/src/dolphin/phase_link/covariance.py
+++ b/src/dolphin/phase_link/covariance.py
@@ -42,7 +42,14 @@ def estimate_stack_covariance_cpu(
     C_arrays : np.ndarray
         The covariance matrix at each pixel, with shape
         (n_rows, n_cols, n_slc, n_slc).
+
+    Raises
+    ------
+    ValueError
+        If `slc_stack` is not complex data.
     """
+    if not np.iscomplexobj(slc_stack):
+        raise ValueError("The SLC stack must be complex.")
     # Get the dimensions
     nslc, rows, cols = slc_stack.shape
     dtype = slc_stack.dtype
@@ -87,7 +94,7 @@ def coh_mat_single(neighbor_stack, cov_mat=None):
     """Given a (n_slc, n_samps) samples, estimate the coherence matrix."""
     nslc = neighbor_stack.shape[0]
     if cov_mat is None:
-        cov_mat = np.zeros((nslc, nslc), dtype=neighbor_stack.dtype)
+        cov_mat = np.zeros((nslc, nslc), dtype="complex64")
 
     for ti in range(nslc):
         # Start with the diagonal equal to 1

--- a/src/dolphin/phase_link/mle.py
+++ b/src/dolphin/phase_link/mle.py
@@ -152,9 +152,7 @@ def run_mle(
 
     # Fill in the PS pixels from the original SLC stack, if it was given
     if np.any(ps_mask):
-        _fill_ps_pixels(
-            mle_est, temp_coh, slc_stack, ps_mask, nodata_mask, strides, avg_mag
-        )
+        _fill_ps_pixels(mle_est, temp_coh, slc_stack, ps_mask, strides, avg_mag)
 
     return mle_est, temp_coh
 
@@ -259,9 +257,7 @@ def _check_all_nans(slc_stack):
         raise PhaseLinkRuntimeError(f"SLC stack[{bad_slc_idxs}] has are all NaNs.")
 
 
-def _fill_ps_pixels(
-    mle_est, temp_coh, slc_stack, ps_mask, nodata_mask, strides, avg_mag
-):
+def _fill_ps_pixels(mle_est, temp_coh, slc_stack, ps_mask, strides, avg_mag):
     """Fill in the PS locations in the MLE estimate with the original SLC data.
 
     Overwrites `mle_est` and `temp_coh` in place.
@@ -276,8 +272,6 @@ def _fill_ps_pixels(
         The original SLC stack, with shape (n_images, n_rows, n_cols)
     ps_mask : ndarray, shape = (rows, cols)
         Boolean mask of pixels marking persistent scatterers (PS).
-    nodata_mask : ndarray, shape = (rows, cols)
-        Boolean mask of pixels marking no data pixels.
     strides : dict
         The look window strides
     avg_mag : np.ndarray, optional

--- a/src/dolphin/phase_link/mle.py
+++ b/src/dolphin/phase_link/mle.py
@@ -317,10 +317,13 @@ def _get_maxes(arr, row_looks, col_looks):
         # No need to pad if we're not looking
         return np.where(arr == arr)
     # Get the max value in each look window
+    # Start by dithering the array to avoid ties in the max
+    arr = arr.copy() + 1e-5 * np.random.rand(*arr.shape)
     max_nums = take_looks(
         arr, row_looks, col_looks, func_type="nanmax", edge_strategy="pad"
     )
-    out_rows, out_cols = np.array(arr.shape) / [row_looks, col_looks]
+    out_rows, out_cols = np.array(arr.shape) // [row_looks, col_looks]
+    # Make sure it's the output size we want:
     max_nums = max_nums[:out_rows, :out_cols]
 
     # Repeat the max values to back to the original size

--- a/tests/test_phase_link_mle.py
+++ b/tests/test_phase_link_mle.py
@@ -153,15 +153,11 @@ def test_ps_fill(slc_samples, strides):
     ps_mask = np.zeros((11, 11), dtype=bool)
     ps_mask[ps_idx, ps_idx] = True
 
-    # all valid data
-    nodata_mask = np.zeros((11, 11), dtype=bool)
-
     mle._fill_ps_pixels(
         mle_est,
         temp_coh,
         slc_stack,
         ps_mask,
-        nodata_mask,
         {"x": strides, "y": strides},
         None,  # avg_mag
     )


### PR DESCRIPTION
The key step this time was `arr = arr.copy() + 1e-5 * np.random.rand(*arr.shape)`, since the `_find_maxes` function was getting confused by ties, which led to a different number of pixels being requested to be filled.