### PR TITLE
fix rounding/loading shapes for stitching

### DIFF
--- a/src/dolphin/io.py
+++ b/src/dolphin/io.py
@@ -4,6 +4,7 @@ This module heavily relies on GDAL and provides many convenience/
 wrapper functions to write/iterate over blocks of large raster files.
 """
 import copy
+import math
 from datetime import date
 from os import fspath
 from pathlib import Path
@@ -273,8 +274,9 @@ def xy_to_rowcol(
     col, row = _apply_gt(ds, filename, x, y, inverse=True)
     # Need to convert to int, otherwise we get a float
     if do_round:
-        row = round(row)
-        col = round(col)
+        # round up to the nearest pixel, instead of banker's rounding
+        row = int(math.floor(row + 0.5))
+        col = int(math.floor(col + 0.5))
     return int(row), int(col)
 
 


### PR DESCRIPTION
this was leading to an occasional error
```python traceback
  File "/u/aurora-r0/staniewi/miniconda3/envs/mapping/bin/dolphin", line 8, in <module>
    sys.exit(main())
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/cli.py", line 22, in main
    run_func(**arg_dict)
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/_log.py", line 94, in wrapper
    result = f(*args, **kwargs)
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/workflows/_run_cli.py", line 26, in run
    s1_disp_stack.run(cfg, debug=debug)
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/_log.py", line 94, in wrapper
    result = f(*args, **kwargs)
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/workflows/s1_disp_stack.py", line 67, in run
    unwrapped_paths = stitch_and_unwrap.run(ifg_list, cfg, debug=debug)
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/_log.py", line 94, in wrapper
    result = f(*args, **kwargs)
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/workflows/stitch_and_unwrap.py", line 38, in run
    stitching.merge_by_date(
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/stitching.py", line 61, in merge_by_date
    merge_images(
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/stitching.py", line 202, in merge_images
    cur_out = _blend_new_arr(
  File "/u/aurora-r0/staniewi/repos/dolphin/src/dolphin/stitching.py", line 289, in _blend_new_arr
    good_pixels = good_pixels & ~nd_mask
ValueError: operands could not be broadcast together with shapes (2363,5057) (2362,5057)
```