### PR TITLE
Workflow tweaks

### DIFF
--- a/src/dolphin/_log.py
+++ b/src/dolphin/_log.py
@@ -27,7 +27,7 @@ __all__ = ["get_log", "log_runtime"]
 
 
 def get_log(
-    debug: bool = False, name: str = "dolphin._log", filename: Optional[str] = None
+    name: str = "dolphin._log", debug: bool = False, filename: Optional[str] = None
 ) -> logging.Logger:
     """Create a nice log format for use across multiple files.
 

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -303,15 +303,7 @@ class VRTStack:
                 # Get the middle part of < >filename</ >
                 fn = line.split(">")[1].strip().split("<")[0]
                 file_strings.append(fn)
-        # double check we got the same count
-        ds = gdal.Open(fspath(vrt_file))
-        count = ds.RasterCount
-        ds = None
-        if count != len(file_strings):
-            raise ValueError(
-                f"Found {len(file_strings)} parsing {vrt_file}, but file has"
-                f" {count} bands."
-            )
+
         testname = file_strings[0].upper()
         if testname.startswith("HDF5:") or testname.startswith("NETCDF:"):
             name_triplets = [name.split(":") for name in file_strings]

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -4,7 +4,7 @@ import math
 import tempfile
 from os import fspath
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 from numpy.typing import DTypeLike
@@ -28,7 +28,7 @@ def merge_by_date(
 
     Parameters
     ----------
-    image_file_list : List[Filename]
+    image_file_list : Iterable[Filename]
         List of paths to images.
     file_date_fmt : Optional[str]
         Format of the date in the filename. Default is %Y%m%d
@@ -71,7 +71,7 @@ def merge_by_date(
 
 
 def merge_images(
-    file_list: List[Filename],
+    file_list: Sequence[Filename],
     outfile: Filename,
     target_aligned_pixels: bool = True,
     driver: str = "ENVI",
@@ -220,13 +220,13 @@ def merge_images(
 
 
 def _group_by_date(
-    file_list: List[Filename], file_date_fmt: str = io.DEFAULT_DATETIME_FORMAT
+    file_list: Iterable[Filename], file_date_fmt: str = io.DEFAULT_DATETIME_FORMAT
 ):
     """Combine Sentinel objects by date.
 
     Parameters
     ----------
-    file_list: List[Filename]
+    file_list: Iterable[Filename]
         path to folder containing CSLC files
     file_date_fmt: str
         format of the date in the filename.
@@ -261,7 +261,7 @@ def _group_by_date(
 
 
 def _blend_new_arr(
-    cur_arr: np.ndarray, new_arr: np.ndarray, nodata_vals: List[Optional[float]]
+    cur_arr: np.ndarray, new_arr: np.ndarray, nodata_vals: Iterable[Optional[float]]
 ):
     """Blend two arrays together, replacing values in cur_arr with new_arr.
 
@@ -274,7 +274,7 @@ def _blend_new_arr(
         The array to blend into.
     new_arr : np.ndarray
         The new array to add/overwrite with.
-    nodata_vals : List[float]
+    nodata_vals : Iterable[float]
         The nodata values to replace in cur_arr.
 
     Returns
@@ -298,7 +298,7 @@ def _blend_new_arr(
 
 
 def _warp_to_projection(
-    filenames: List[Filename],
+    filenames: Iterable[Filename],
     dirname: Filename,
     projection: str,
     res: Tuple[float, float],
@@ -307,7 +307,7 @@ def _warp_to_projection(
 
     Parameters
     ----------
-    filenames : List[Filename]
+    filenames : Iterable[Filename]
         List of filenames to warp.
     dirname : Filename
         The directory to write the warped files to.
@@ -351,13 +351,13 @@ def _warp_to_projection(
     return warped_files
 
 
-def _get_mode_projection(filenames: List[Filename]) -> str:
+def _get_mode_projection(filenames: Iterable[Filename]) -> str:
     """Get the most common projection in the list."""
     projs = [gdal.Open(fspath(fn)).GetProjection() for fn in filenames]
     return max(set(projs), key=projs.count)
 
 
-def _get_resolution(filenames: List[Filename]) -> Tuple[float, float]:
+def _get_resolution(filenames: Iterable[Filename]) -> Tuple[float, float]:
     """Get the most common resolution in the list."""
     gts = [gdal.Open(fspath(fn)).GetGeoTransform() for fn in filenames]
     res = [(gt[1], gt[5]) for gt in gts]
@@ -418,7 +418,7 @@ def _get_combined_bounds_gt(
     return bounds, gt_total
 
 
-def _get_output_shape(bounds, res):
+def _get_output_shape(bounds: Iterable[float], res: Tuple[float, float]):
     """Get the output shape of the combined image."""
     left, bottom, right, top = bounds
     # Always round up to the nearest pixel, instead of banker's rounding
@@ -427,7 +427,7 @@ def _get_output_shape(bounds, res):
     return int(out_height), int(out_width)
 
 
-def _align_bounds(bounds, res):
+def _align_bounds(bounds: Iterable[float], res: Tuple[float, float]):
     left, bottom, right, top = bounds
     left = math.floor(left / res[0]) * res[0]
     right = math.ceil(right / res[0]) * res[0]
@@ -437,7 +437,7 @@ def _align_bounds(bounds, res):
 
 
 def _nodata_to_zero(
-    infile,
+    infile: Filename,
     outfile: Optional[Filename] = None,
     ext: Optional[str] = None,
     in_band: int = 1,

--- a/src/dolphin/workflows/__init__.py
+++ b/src/dolphin/workflows/__init__.py
@@ -1,3 +1,4 @@
 """Tools for creating workflows and running displacement workflows."""
 from ._enums import *  # noqa
+from ._grouping import *  # noqa
 from .config import *  # noqa

--- a/src/dolphin/workflows/_grouping.py
+++ b/src/dolphin/workflows/_grouping.py
@@ -1,0 +1,82 @@
+import itertools
+import re
+from pathlib import Path
+from typing import Dict, List, Pattern, Sequence, Union
+
+from dolphin._log import get_log
+from dolphin._types import Filename
+
+from .config import OPERA_BURST_RE
+
+logger = get_log(__name__)
+
+__all__ = ["group_by_burst"]
+
+
+def group_by_burst(
+    file_list: Sequence[Filename],
+    burst_id_fmt: Union[str, Pattern[str]] = OPERA_BURST_RE,
+    minimum_slcs: int = 2,
+) -> Dict[str, List[Path]]:
+    """Group Sentinel CSLC files by burst.
+
+    Parameters
+    ----------
+    file_list: List[Filename]
+        path to folder containing CSLC files
+    burst_id_fmt: str
+        format of the burst id in the filename.
+        Default is [OPERA_BURST_RE][]
+    minimum_slcs: int
+        Minimum number of SLCs needed to run the workflow for each burst.
+        If there are fewer SLCs in a burst, it will be skipped and
+        a warning will be logged.
+
+    Returns
+    -------
+    dict
+        key is the burst id of the SLC acquisition
+        Value is a list of Paths on that burst:
+        {
+            't087_185678_iw2': [Path(...), Path(...),],
+            't087_185678_iw3': [Path(...),... ],
+        }
+    """
+
+    def get_burst_id(filename):
+        m = re.search(burst_id_fmt, str(filename))
+        if not m:
+            raise ValueError(f"Could not parse burst id from {filename}")
+        return m.group()
+
+    def sort_by_burst_id(file_list):
+        """Sort files by burst id."""
+        burst_ids = [get_burst_id(f) for f in file_list]
+        file_burst_tups = sorted(
+            [(Path(f), d) for f, d in zip(file_list, burst_ids)],
+            # use the date or dates as the key
+            key=lambda f_d_tuple: f_d_tuple[1],  # type: ignore
+        )
+        # Unpack the sorted pairs with new sorted values
+        file_list, burst_ids = zip(*file_burst_tups)  # type: ignore
+        return file_list
+
+    sorted_file_list = sort_by_burst_id(file_list)
+    # Now collapse into groups, sorted by the burst_id
+    grouped_images = {
+        burst_id: list(g)
+        for burst_id, g in itertools.groupby(
+            sorted_file_list, key=lambda x: get_burst_id(x)
+        )
+    }
+    # Make sure that each burst has at least the minimum number of SLCs
+    out = {}
+    for burst_id, slc_list in grouped_images.items():
+        if len(slc_list) < minimum_slcs:
+            logger.warning(
+                f"Skipping burst {burst_id} because it has only {len(slc_list)} SLCs."
+                f"Minimum number of SLCs is {minimum_slcs}"
+            )
+        else:
+            out[burst_id] = slc_list
+    return out

--- a/src/dolphin/workflows/s1_disp.py
+++ b/src/dolphin/workflows/s1_disp.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python
-import itertools
-import re
 from pathlib import Path
 from pprint import pformat
-from typing import Dict, List, Optional, Pattern, Sequence, Union
+from typing import Dict, List, Optional
 
 from dolphin._log import get_log, log_runtime
-from dolphin._types import Filename
 from dolphin.interferogram import VRTInterferogram
 
 from . import stitch_and_unwrap, wrapped_phase
-from .config import OPERA_BURST_RE, Workflow
+from ._grouping import group_by_burst
+from .config import Workflow
 
 
 @log_runtime
@@ -30,7 +28,7 @@ def run(cfg: Workflow, debug: bool = False, log_file: Optional[str] = None):
     logger.debug(pformat(cfg.dict()))
 
     try:
-        grouped_slc_files = _group_by_burst(cfg.inputs.cslc_file_list)
+        grouped_slc_files = group_by_burst(cfg.inputs.cslc_file_list)
     except ValueError as e:
         # Make sure it's not some other ValueError
         if "Could not parse burst id" not in str(e):
@@ -82,76 +80,6 @@ def run(cfg: Workflow, debug: bool = False, log_file: Optional[str] = None):
             new_name = cfg.outputs.output_directory / name
             logger.info(f"Moving {p} to {new_name}")
             (p.parent / name).rename(new_name)
-
-
-def _group_by_burst(
-    file_list: Sequence[Filename],
-    burst_id_fmt: Union[str, Pattern[str]] = OPERA_BURST_RE,
-    minimum_slcs: int = 2,
-) -> Dict[str, List[Path]]:
-    """Group Sentinel CSLC files by burst.
-
-    Parameters
-    ----------
-    file_list: List[Filename]
-        path to folder containing CSLC files
-    burst_id_fmt: str
-        format of the burst id in the filename.
-        Default is [OPERA_BURST_RE][]
-    minimum_slcs: int
-        Minimum number of SLCs needed to run the workflow for each burst.
-        If there are fewer SLCs in a burst, it will be skipped and
-        a warning will be logged.
-
-    Returns
-    -------
-    dict
-        key is the burst id of the SLC acquisition
-        Value is a list of Paths on that burst:
-        {
-            't087_185678_iw2': [Path(...), Path(...),],
-            't087_185678_iw3': [Path(...),... ],
-        }
-    """
-
-    def get_burst_id(filename):
-        m = re.search(burst_id_fmt, str(filename))
-        if not m:
-            raise ValueError(f"Could not parse burst id from {filename}")
-        return m.group()
-
-    def sort_by_burst_id(file_list):
-        """Sort files by burst id."""
-        burst_ids = [get_burst_id(f) for f in file_list]
-        file_burst_tups = sorted(
-            [(Path(f), d) for f, d in zip(file_list, burst_ids)],
-            # use the date or dates as the key
-            key=lambda f_d_tuple: f_d_tuple[1],  # type: ignore
-        )
-        # Unpack the sorted pairs with new sorted values
-        file_list, burst_ids = zip(*file_burst_tups)  # type: ignore
-        return file_list
-
-    logger = get_log()
-    sorted_file_list = sort_by_burst_id(file_list)
-    # Now collapse into groups, sorted by the burst_id
-    grouped_images = {
-        burst_id: list(g)
-        for burst_id, g in itertools.groupby(
-            sorted_file_list, key=lambda x: get_burst_id(x)
-        )
-    }
-    # Make sure that each burst has at least the minimum number of SLCs
-    out = {}
-    for burst_id, slc_list in grouped_images.items():
-        if len(slc_list) < minimum_slcs:
-            logger.warning(
-                f"Skipping burst {burst_id} because it has only {len(slc_list)} SLCs."
-                f"Minimum number of SLCs is {minimum_slcs}"
-            )
-        else:
-            out[burst_id] = slc_list
-    return out
 
 
 def _create_burst_cfg(

--- a/tests/test_workflows_s1_disp.py
+++ b/tests/test_workflows_s1_disp.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from dolphin.workflows import s1_disp
+from dolphin.workflows import group_by_burst
 
 
 def test_group_by_burst():
@@ -26,20 +26,20 @@ def test_group_by_burst():
     }
     in_files = list(chain.from_iterable(expected.values()))
 
-    assert s1_disp._group_by_burst(in_files) == expected
+    assert group_by_burst(in_files) == expected
 
     # Any order should work
     random.shuffle(in_files)
     # but the order of the lists of each key may be different
-    for burst, file_list in s1_disp._group_by_burst(in_files).items():
+    for burst, file_list in group_by_burst(in_files).items():
         assert sorted(file_list) == sorted(expected[burst])
 
 
 def test_group_by_burst_non_opera():
     with pytest.raises(ValueError, match="Could not parse burst id"):
-        s1_disp._group_by_burst(["20200101.slc", "20200202.slc"])
+        group_by_burst(["20200101.slc", "20200202.slc"])
         # A combination should still error
-        s1_disp._group_by_burst(
+        group_by_burst(
             [
                 "20200101.slc",
                 Path("t087_185679_iw1/20180210/t087_185679_iw1_20180210_VV.h5"),


### PR DESCRIPTION
- Fixes a stitching error which would only sometimes come up. We were writing in a background thread, but that would sometimes lead to results like this:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/8291800/220506131-4ed0fd72-76b9-499f-84a7-191c8ec8f4c5.png">
This is the fix:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/8291800/220506176-bb2a3c38-1621-45df-9e2e-78eb1373c3fd.png">
(where the upper right line artifact is unrelated to the stitching, but is a DEM difference)
- Makes some of the input type hints more general
- Removes the check on number of bands in the VRTStack XML parsing so that we can use it on VRTInterferogram (which has one band, but two files)