### PR TITLE
Fix strided output PS filling

### DIFF
--- a/src/dolphin/io.py
+++ b/src/dolphin/io.py
@@ -538,8 +538,8 @@ def write_block(
 class Writer(BackgroundWriter):
     """Class to write data to files in a background thread."""
 
-    def __init__(self, max_queue=0, **kw):
-        super().__init__(nq=max_queue, **kw)
+    def __init__(self, max_queue: int = 0, **kwargs):
+        super().__init__(nq=max_queue, name="Writer", **kwargs)
 
     def write(
         self, data: ArrayLike, filename: Filename, row_start: int, col_start: int
@@ -575,15 +575,15 @@ class EagerLoader(BackgroundReader):
 
     def __init__(
         self,
-        filename,
+        filename: Filename,
         block_shape: Tuple[int, int],
         overlaps: Tuple[int, int] = (0, 0),
         skip_empty: bool = True,
         nodata_mask: Optional[ArrayLike] = None,
-        queue_size=2,
-        timeout=_DEFAULT_TIMEOUT,
+        queue_size: int = 2,
+        timeout: float = _DEFAULT_TIMEOUT,
     ):
-        super().__init__(nq=queue_size, timeout=timeout)
+        super().__init__(nq=queue_size, timeout=timeout, name="EagerLoader")
         self.filename = filename
         # Set up the generator of ((row_start, row_end), (col_start, col_end))
         xsize, ysize = get_raster_xysize(filename)
@@ -636,7 +636,7 @@ class EagerLoader(BackgroundReader):
 
 
 def _slice_iterator(
-    arr_shape,
+    arr_shape: Tuple[int, int],
     block_shape: Tuple[int, int],
     overlaps: Tuple[int, int] = (0, 0),
     start_offsets: Tuple[int, int] = (0, 0),
@@ -746,7 +746,7 @@ def get_max_block_shape(
     )
 
 
-def get_raster_chunk_size(filename) -> List[int]:
+def get_raster_chunk_size(filename: Filename) -> List[int]:
     """Get size the raster's chunks on disk.
 
     This is called blockXsize, blockYsize by GDAL.

--- a/src/dolphin/io.py
+++ b/src/dolphin/io.py
@@ -3,12 +3,11 @@
 This module heavily relies on GDAL and provides many convenience/
 wrapper functions to write/iterate over blocks of large raster files.
 """
-import copy
 import math
 from datetime import date
 from os import fspath
 from pathlib import Path
-from typing import Any, Dict, Generator, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, DTypeLike
@@ -706,11 +705,12 @@ slice(90, 190, None)), (slice(90, 180, None), slice(180, 250, None))]
 
 
 def get_max_block_shape(
-    filename, nstack: int, max_bytes: float = 64e6
+    filename: Filename, nstack: int, max_bytes: float = 64e6
 ) -> Tuple[int, int]:
-    """Find shape to load from GDAL-readable `filename` with memory size < `max_bytes`.
+    """Find a block shape to load from `filename` with memory size < `max_bytes`.
 
-    Attempts to get an integer number of tiles from the file to avoid partial tiles.
+    Attempts to get an integer number of chunks ("tiles" for geotiffs) from the
+    file to avoid partial tiles.
 
     Parameters
     ----------
@@ -724,47 +724,33 @@ def get_max_block_shape(
 
     Returns
     -------
-    tuple[int]:
+    Tuple[int, int]:
         (num_rows, num_cols) shape of blocks to load from `vrt_file`
     """
-    blockX, blockY = get_raster_block_size(filename)
+    chunk_cols, chunk_rows = get_raster_chunk_size(filename)
     xsize, ysize = get_raster_xysize(filename)
     # If it's written by line, load at least 16 lines at a time
-    blockX = min(max(16, blockX), xsize)
-    blockY = min(max(16, blockY), ysize)
+    chunk_cols = min(max(16, chunk_cols), xsize)
+    chunk_rows = min(max(16, chunk_rows), ysize)
 
     ds = gdal.Open(fspath(filename))
     shape = (ds.RasterYSize, ds.RasterXSize)
-    # get the data type from the raster
-    dt = gdal_to_numpy_type(ds.GetRasterBand(1).DataType)
-    # get the size of the data type
-    nbytes = np.dtype(dt).itemsize
-
-    full_shape = [nstack, *shape]
-    chunk_size_3d = [nstack, blockY, blockX]
-
-    # Find size of 3D chunk to load while staying at ~`max_bytes` bytes of RAM
-    chunks_per_block = max_bytes / (np.prod(chunk_size_3d) * nbytes)
-    row_chunks, col_chunks = 1, 1
-    cur_block_shape = list(copy.copy(chunk_size_3d))
-    while chunks_per_block > 1:
-        # First keep incrementing the number of columns we grab at once time
-        if col_chunks * chunk_size_3d[2] < full_shape[2]:
-            col_chunks += 1
-            cur_block_shape[2] = min(col_chunks * chunk_size_3d[2], full_shape[2])
-        # Then increase the row size if still haven't hit `max_bytes`
-        elif row_chunks * chunk_size_3d[1] < full_shape[1]:
-            row_chunks += 1
-            cur_block_shape[1] = min(row_chunks * chunk_size_3d[1], full_shape[1])
-        else:
-            break
-        chunks_per_block = max_bytes / (np.prod(cur_block_shape) * nbytes)
-    rows, cols = cur_block_shape[1:]
-    return (rows, cols)
+    # get the size of the data type from the raster
+    nbytes = gdal_to_numpy_type(ds.GetRasterBand(1).DataType).itemsize
+    return _increment_until_max(
+        max_bytes=max_bytes,
+        file_chunk_size=[chunk_rows, chunk_cols],
+        shape=shape,
+        nstack=nstack,
+        bytes_per_pixel=nbytes,
+    )
 
 
-def get_raster_block_size(filename):
-    """Get the raster's (blockXsize, blockYsize) on disk."""
+def get_raster_chunk_size(filename) -> List[int]:
+    """Get size the raster's chunks on disk.
+
+    This is called blockXsize, blockYsize by GDAL.
+    """
     ds = gdal.Open(fspath(filename))
     block_size = ds.GetRasterBand(1).GetBlockSize()
     for i in range(2, ds.RasterCount + 1):
@@ -776,3 +762,37 @@ def get_raster_block_size(filename):
 
 def _format_date_pair(start: date, end: date, fmt=DEFAULT_DATETIME_FORMAT) -> str:
     return f"{start.strftime(fmt)}_{end.strftime(fmt)}"
+
+
+def _increment_until_max(
+    max_bytes: float,
+    file_chunk_size: Sequence[int],
+    shape: Tuple[int, int],
+    nstack: int,
+    bytes_per_pixel: int = 8,
+) -> Tuple[int, int]:
+    """Find size of 3D chunk to load while staying at ~`max_bytes` bytes of RAM."""
+    chunk_rows, chunk_cols = file_chunk_size
+
+    # How many chunks can we fit in max_bytes?
+    chunks_per_block = max_bytes / (
+        (nstack * chunk_rows * chunk_cols) * bytes_per_pixel
+    )
+    num_chunks = [1, 1]
+    cur_block_shape = [chunk_rows, chunk_cols]
+
+    idx = 1  # start incrementing cols
+    while chunks_per_block > 1 and tuple(cur_block_shape) != tuple(shape):
+        # Alternate between adding a row and column chunk by flipping the idx
+        chunk_idx = idx % 2
+        nc = num_chunks[chunk_idx]
+        chunk_size = file_chunk_size[chunk_idx]
+
+        cur_block_shape[chunk_idx] = min(nc * chunk_size, shape[chunk_idx])
+
+        chunks_per_block = max_bytes / (
+            nstack * np.prod(cur_block_shape) * bytes_per_pixel
+        )
+        num_chunks[chunk_idx] += 1
+        idx += 1
+    return cur_block_shape[0], cur_block_shape[1]

--- a/src/dolphin/phase_link/_mle_cpu.py
+++ b/src/dolphin/phase_link/_mle_cpu.py
@@ -63,7 +63,7 @@ def run_cpu(
     if output_cov_file:
         covariance._save_covariance(output_cov_file, C_arrays)
 
-    output_phase = mle_stack(C_arrays, beta, reference_idx)
+    output_phase = mle_stack(C_arrays, beta, reference_idx, n_workers=n_workers)
     cpx_phase = np.exp(1j * output_phase)
     # Get the temporal coherence
     temp_coh = metrics.estimate_temp_coh(cpx_phase, C_arrays)

--- a/src/dolphin/phase_link/_mle_gpu.py
+++ b/src/dolphin/phase_link/_mle_gpu.py
@@ -20,6 +20,7 @@ def run_gpu(
     use_slc_amp: bool = True,
     output_cov_file: Optional[Filename] = None,
     threads_per_block: Tuple[int, int] = (16, 16),
+    free_mem: bool = False,
     **kwargs,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Run the GPU version of the stack covariance estimator and MLE solver.
@@ -46,6 +47,9 @@ def run_gpu(
     threads_per_block : Tuple[int, int], optional
         The number of threads per block to use for the GPU kernel.
         By default (16, 16)
+    free_mem : bool, optional
+        Whether to free the memory of the covariance matrix after the MLE
+        estimation. By default False.
 
     Returns
     -------
@@ -91,7 +95,10 @@ def run_gpu(
     # # https://docs.cupy.dev/en/stable/user_guide/memory.html
     # may just be cached a lot of the huge memory available on aurora
     # But if we need to free GPU memory:
-    # cp.get_default_memory_pool().free_all_blocks()
+    if free_mem:
+        del d_slc_stack
+        del d_C_arrays
+        cp.get_default_pinned_memory_pool().free_all_blocks()
 
     if use_slc_amp:
         # use the amplitude from the original SLCs, accounting for strides

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -406,14 +406,14 @@ class VRTStack:
         if use_nodata_mask:
             logger.info("Nodata mask not implemented, skipping")
 
-        loader = io.EagerLoader(
+        self._loader = io.EagerLoader(
             self.outfile,
             block_shape=block_shape,
             overlaps=overlaps,
             skip_empty=skip_empty,
             nodata_mask=ndm,
         )
-        yield from loader.iter_blocks()
+        yield from self._loader.iter_blocks()
 
     def _get_block_shape(self, max_bytes=DEFAULT_BLOCK_BYTES):
         test_file = self._get_non_vrt_file(self._gdal_file_strings[0])

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -20,7 +20,7 @@ DEFAULT_BLOCK_BYTES = 32e6
 
 
 class VRTStack:
-    """Class for creating a VRT for a stack of raster files.
+    """Class for creating a virtual stack of raster files.
 
     Attributes
     ----------
@@ -140,18 +140,18 @@ class VRTStack:
             )
 
             for idx, filename in enumerate(self._gdal_file_strings, start=1):
-                block_size = io.get_raster_block_size(filename)
-                # blocks in a vrt have a min of 16, max of 2**14=16384
+                chunk_size = io.get_raster_chunk_size(filename)
+                # chunks in a vrt have a min of 16, max of 2**14=16384
                 # https://github.com/OSGeo/gdal/blob/2530defa1e0052827bc98696e7806037a6fec86e/frmts/vrt/vrtrasterband.cpp#L339
-                if any([b < 16 for b in block_size]) or any(
-                    [b > 16384 for b in block_size]
+                if any([b < 16 for b in chunk_size]) or any(
+                    [b > 16384 for b in chunk_size]
                 ):
-                    block_str = ""
+                    chunk_str = ""
                 else:
-                    block_str = (
-                        f'blockXSize="{block_size[0]}" blockYSize="{block_size[1]}"'
+                    chunk_str = (
+                        f'blockXSize="{chunk_size[0]}" blockYSize="{chunk_size[1]}"'
                     )
-                outstr = f"""  <VRTRasterBand dataType="{self.dtype}" band="{idx}" {block_str}>
+                outstr = f"""  <VRTRasterBand dataType="{self.dtype}" band="{idx}" {chunk_str}>
     <SimpleSource>
       <SourceFilename>{filename}</SourceFilename>
       <SourceBand>1</SourceBand>

--- a/src/dolphin/stack.py
+++ b/src/dolphin/stack.py
@@ -395,8 +395,9 @@ class VRTStack:
 
         Yields
         ------
-        Tuple[Tuple[int, int], Tuple[int, int]]
-            Iterator of ((row_start, row_stop), (col_start, col_stop))
+        Tuple[np.ndarray, Tuple[slice, slice]]
+            Iterator of (data, (slice(row_start, row_stop), slice(col_start, col_stop))
+
         """
         if block_shape is None:
             block_shape = self._get_block_shape(max_bytes=max_bytes)

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -383,7 +383,18 @@ def take_looks(arr, row_looks, col_looks, func_type="nansum", edge_strategy="cut
         return arr
 
     if arr.ndim >= 3:
-        return xp.stack([take_looks(a, row_looks, col_looks, func_type) for a in arr])
+        return xp.stack(
+            [
+                take_looks(
+                    a,
+                    row_looks,
+                    col_looks,
+                    func_type=func_type,
+                    edge_strategy=edge_strategy,
+                )
+                for a in arr
+            ]
+        )
 
     arr = _make_dims_multiples(arr, row_looks, col_looks, how=edge_strategy)
 

--- a/src/dolphin/utils.py
+++ b/src/dolphin/utils.py
@@ -49,7 +49,7 @@ def gdal_to_numpy_type(gdal_type: Union[str, int]) -> np.dtype:
     """Convert gdal type to numpy type."""
     if isinstance(gdal_type, str):
         gdal_type = gdal.GetDataTypeByName(gdal_type)
-    return gdal_array.GDALTypeCodeToNumericTypeCode(gdal_type)
+    return np.dtype(gdal_array.GDALTypeCodeToNumericTypeCode(gdal_type))
 
 
 def get_dates(filename: Filename, fmt: str = "%Y%m%d") -> List[datetime.date]:


### PR DESCRIPTION
#57 has more detail on the main problem this is addressing: When using a downsampled output (strides > 1), use the average PS within each stride window


This also fixes
- a problem where the script would hang after an exception because of a queue backup for the `EagerLoader`
- a speedup for the CPU version, where we're using scipy's `eigh`, which can compute only a single eigenvector.