### PR TITLE
Fix `load_gdal` to accept one type of row/col slice

### DIFF
--- a/src/dolphin/shp/_glrt.py
+++ b/src/dolphin/shp/_glrt.py
@@ -127,33 +127,3 @@ def get_cutoff(alpha: float, N: int) -> float:
         return n_alpha_to_cutoff[(N, alpha)]
     except KeyError:
         raise ValueError(f"Not implemented for {N = }, {alpha = }")
-
-
-# # Note: the results were computed using the following:
-# from numpy import log as ln
-# from scipy.stats import rayleigh
-# from joblib import Parallel, delayed
-# import pandas as pd
-# from itertools import product
-# def get_test_stat_glrt(N, nsim=500, alpha=0.05, scale=10):
-#     x = rayleigh.rvs(scale=scale, size=(nsim, 2 * N))
-
-#     scale2_p = (x[:, :N] ** 2).mean(axis=1) / 2
-#     scale2_q = (x[:, N:] ** 2).mean(axis=1) / 2
-#     scale2_pooled = (scale2_p + scale2_q) / 2
-#     return 2 * ln(scale2_pooled) - ln(scale2_p) - ln(scale2_q)  # leave off the *N
-# def get_alpha_cutoff2(alpha, N, nsim=50_000, scale=10):
-#     return np.percentile(
-#         get_test_stat_glrt(N, nsim=nsim, alpha=alpha, scale=scale), 100 * (1 - alpha)
-#     )
-# def _run(N, alpha, scale):
-#     return (N, alpha, scale, get_alpha_cutoff2(alpha=alpha, N=N, scale=scale))
-# Narr = list(range(1, 301))
-# scales = (1, 10, 50)
-# alphas = [0.05, 0.01, 0.005, 0.001]
-# results = Parallel(n_jobs=30)(
-#     delayed(_run)(*row) for row in product(Narr, alphas, scales)
-# )
-# df = pd.DataFrame(data=results, columns=['N', 'alpha', 'scale', 'cutoff'])
-# d2 = df.groupby(['N', 'alpha']).mean().round(4)[['cutoff']]
-# d2.to_csv("dolphin/shp/glrt_cutoffs.csv", index=True)

--- a/src/dolphin/workflows/s1_disp.py
+++ b/src/dolphin/workflows/s1_disp.py
@@ -151,8 +151,6 @@ def run(
             conncomp_filename=cc_p,
             tcorr_filename=stitched_tcorr_file,
             spatial_corr_filename=s_corr_p,
-            # TODO: How am i going to create the output name?
-            # output_name=cfg.outputs.output_name,
             output_name=output_name,
             corrections={},
             pge_runconfig=pge_runconfig,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -19,7 +19,18 @@ def test_get_raster_xysize(raster_100_by_200):
     assert (200, 100) == io.get_raster_xysize(raster_100_by_200)
 
 
-def test_load_slice(raster_100_by_200):
+def test_load_1_slice(raster_100_by_200):
+    arr = io.load_gdal(raster_100_by_200)
+    block = io.load_gdal(raster_100_by_200, rows=slice(0, 10))
+    assert block.shape == (10, 200)
+    npt.assert_allclose(block, arr[:10, :])
+
+    block = io.load_gdal(raster_100_by_200, cols=slice(10, 20))
+    assert block.shape == (100, 10)
+    npt.assert_allclose(block, arr[:, 10:20])
+
+
+def test_load_slices(raster_100_by_200):
     arr = io.load_gdal(raster_100_by_200)
     block = io.load_gdal(raster_100_by_200, rows=slice(0, 10), cols=slice(0, 10))
     assert block.shape == (10, 10)
@@ -28,6 +39,19 @@ def test_load_slice(raster_100_by_200):
     block = io.load_gdal(raster_100_by_200, rows=slice(10, 20), cols=slice(10, 20))
     assert block.shape == (10, 10)
     npt.assert_allclose(block, arr[10:20, 10:20])
+
+
+def test_load_none_slices(raster_100_by_200):
+    arr = io.load_gdal(raster_100_by_200)
+    block = io.load_gdal(raster_100_by_200, rows=slice(0, 10), cols=slice(None))
+    assert block.shape == (10, 200)
+    npt.assert_allclose(block, arr[:10, :])
+
+    block = io.load_gdal(
+        raster_100_by_200, rows=slice(None, None, None), cols=slice(10, 20)
+    )
+    assert block.shape == (100, 10)
+    npt.assert_allclose(block, arr[:, 10:20])
 
 
 def test_load_slice_oob(raster_100_by_200):


### PR DESCRIPTION
Error found from `sweets` testing, since it needed both kinds before, and you also couldn't pass a `None` or `slice(None)`.

Two other commented code sections removed.