### PR TITLE
Save multilooked PS file, workflow bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Created a script to test the incremental/near-real-time version of phase linking
 - Added a new CLI command `dolphin unwrap` to unwrap a single interferogram/a directory of interferograms in parallel.
 - Added ability to specify a glob pattern for input CSLC files in the YAML config
+- Saves a multilooked PS mask for the default workflow output
+- Allows the user to specify a desired bounds for the final stitched result
 
 **Changes**
 
@@ -30,6 +32,7 @@
 **Fixed**
 
 - Calculating the nodata mask using the correct input geotransform
+- Trims the overlapped region of the phase linking step when iterating in blocks
 
 **Dependencies**
 

--- a/src/dolphin/phase_link/mle.py
+++ b/src/dolphin/phase_link/mle.py
@@ -337,10 +337,15 @@ def _fill_ps_pixels(
         PS pixels to fill within each look window.
     reference_idx : int, default = 0
         SLC to use as reference for PS pixels. All pixel values are multiplied
-        by the conjugate of
+        by the conjugate of this index
     use_max_ps : bool, optional
         If True, use the brightest PS pixel in each look window to fill in the
         MLE estimate. If False, use the average of all PS pixels in each look window.
+
+    Returns
+    -------
+    ps_masked_looked : ndarray
+        boolean array of PS, multilooked (using "any") to same size as `mle_est`
     """
     if avg_mag is None:
         # Get the average magnitude of the SLC stack

--- a/src/dolphin/stitching.py
+++ b/src/dolphin/stitching.py
@@ -27,6 +27,11 @@ def merge_by_date(
     output_dir: Filename = ".",
     driver: str = "ENVI",
     output_suffix: str = ".int",
+    out_nodata: Optional[Union[float, str]] = 0,
+    in_nodata: Optional[Union[float, str]] = None,
+    out_bounds: Optional[Bbox] = None,
+    out_bounds_epsg: Optional[int] = None,
+    options: Optional[Sequence[str]] = io.DEFAULT_ENVI_OPTIONS,
     overwrite: bool = False,
 ) -> dict[tuple[date, ...], Path]:
     """Group images from the same date and merge into one image per date.
@@ -43,6 +48,19 @@ def merge_by_date(
         GDAL driver to use for output. Default is ENVI.
     output_suffix : str
         Suffix to use to output stitched filenames. Default is ".int"
+    out_nodata : Optional[float | str]
+        Nodata value to use for output file. Default is 0.
+    in_nodata : Optional[float | str]
+        Override the files' `nodata` and use `in_nodata` during merging.
+    out_bounds: Optional[tuple[float]]
+        if provided, forces the output image bounds to
+            (left, bottom, right, top).
+        Otherwise, computes from the outside of all input images.
+    out_bounds_epsg: Optional[int]
+        EPSG code for the `out_bounds`.
+        If not provided, assumed to match the projections of `file_list`.
+    options : Optional[Sequence[str]]
+        Driver-specific creation options passed to GDAL. Default is ["SUFFIX=ADD"]
     overwrite : bool
         Overwrite existing files. Default is False.
 
@@ -76,6 +94,11 @@ def merge_by_date(
             outfile=outfile,
             driver=driver,
             overwrite=overwrite,
+            out_nodata=out_nodata,
+            out_bounds=out_bounds,
+            out_bounds_epsg=out_bounds_epsg,
+            in_nodata=in_nodata,
+            options=options,
         )
 
         stitched_acq_times[dates] = outfile
@@ -91,7 +114,7 @@ def merge_images(
     out_bounds_epsg: Optional[int] = None,
     strides: dict[str, int] = {"x": 1, "y": 1},
     driver: str = "ENVI",
-    out_nodata: Optional[float] = 0,
+    out_nodata: Optional[Union[float, str]] = 0,
     out_dtype: Optional[DTypeLike] = None,
     in_nodata: Optional[Union[float, str]] = None,
     resample_alg: str = "lanczos",
@@ -123,12 +146,12 @@ def merge_images(
         subsample factor: {"x": x strides, "y": y strides}
     driver : str
         GDAL driver to use for output file. Default is ENVI.
-    out_nodata : Optional[float]
+    out_nodata : Optional[float | str]
         Nodata value to use for output file. Default is 0.
     out_dtype : Optional[DTypeLike]
         Output data type. Default is None, which will use the data type
         of the first image in the list.
-    in_nodata : Optional[float]
+    in_nodata : Optional[float | str]
         Override the files' `nodata` and use `in_nodata` during merging.
     resample_alg : str, default="lanczos"
         Method for gdal to use for reprojection.

--- a/src/dolphin/workflows/config.py
+++ b/src/dolphin/workflows/config.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Extra, Field, PrivateAttr, root_validator, valid
 
 from dolphin import __version__ as _dolphin_version
 from dolphin._log import get_log
+from dolphin._types import Bbox
 from dolphin.io import DEFAULT_HDF5_OPTIONS, DEFAULT_TIFF_OPTIONS
 from dolphin.utils import get_cpu_count, get_dates, sort_files_by_date
 
@@ -246,6 +247,16 @@ class OutputOptions(BaseModel, extra=Extra.forbid):
             " strides of [4, 2] would turn an input resolution of [5, 10] into an"
             " output resolution of [20, 20]."
         ),
+    )
+    bounds: Optional[Bbox] = Field(
+        None,
+        description=(
+            "Area of interest: (left, bottom, right, top) longitude/latitude "
+            "e.g. `bbox=(-150.2,65.0,-150.1,65.5)`"
+        ),
+    )
+    bounds_epsg: int = Field(
+        4326, description="EPSG code for the `bounds`, if specified."
     )
 
     hdf5_creation_options: dict = Field(

--- a/src/dolphin/workflows/single.py
+++ b/src/dolphin/workflows/single.py
@@ -167,7 +167,7 @@ def run_wrapped_phase_single(
         nodata=0,
     )
 
-    # Create the empty compressed temporal coherence file
+    # Create the empty compressed SHP count file
     shp_counts_file = output_folder / f"shp_counts_{start_end}.tif"
     io.write_arr(
         arr=None,
@@ -262,7 +262,7 @@ def run_wrapped_phase_single(
         # Save avg coh index
         if avg_coh is not None:
             writer.queue_write(avg_coh, avg_coh_file, out_row_start, out_col_start)
-            writer.queue_write(avg_coh, avg_coh_file, out_row_start, out_col_start)
+
         # Save the SHP counts for each pixel (if not using Rect window)
         shp_counts = np.sum(neighbor_arrays[rows, cols], axis=(-2, -1))
         writer.queue_write(shp_counts, shp_counts_file, out_row_start, out_col_start)

--- a/src/dolphin/workflows/stitch_and_unwrap.py
+++ b/src/dolphin/workflows/stitch_and_unwrap.py
@@ -62,6 +62,8 @@ def run(
         image_file_list=ifg_file_list,  # type: ignore
         file_date_fmt=cfg.input_options.cslc_date_fmt,
         output_dir=stitched_ifg_dir,
+        out_bounds=cfg.output_options.bounds,
+        out_bounds_epsg=cfg.output_options.bounds_epsg,
     )
 
     # Estimate the spatial correlation from the stitched interferogram
@@ -76,6 +78,8 @@ def run(
         outfile=stitched_tcorr_file,
         driver="GTiff",
         overwrite=False,
+        out_bounds=cfg.output_options.bounds,
+        out_bounds_epsg=cfg.output_options.bounds_epsg,
     )
 
     # #####################################

--- a/src/dolphin/workflows/wrapped_phase.py
+++ b/src/dolphin/workflows/wrapped_phase.py
@@ -86,9 +86,9 @@ def run(cfg: Workflow, debug: bool = False) -> tuple[list[Path], Path, Path]:
             block_size_gb=cfg.worker_settings.block_size_gb,
         )
 
-    # TODO: Need a good way to store the nslc attribute in the PS file...
-    # If we pre-compute it from some big stack, we need to use that for SHP
-    # finding, not use the size of `slc_vrt_file`
+    # Save a looked version of the PS mask too
+    strides = cfg.output_options.strides
+    ps.multilook_ps_mask(strides=strides, ps_mask_file=cfg.ps_options._output_file)
 
     # #########################
     # phase linking/EVD step
@@ -107,13 +107,17 @@ def run(cfg: Workflow, debug: bool = False) -> tuple[list[Path], Path, Path]:
         else:
             watcher = None
 
+        # TODO: Need a good way to store the nslc attribute in the PS file...
+        # If we pre-compute it from some big stack, we need to use that for SHP
+        # finding, not use the size of `slc_vrt_file`
+        shp_nslc = None
         if cfg.workflow_name == "single":
             phase_linked_slcs, comp_slc_file, tcorr_file = (
                 single.run_wrapped_phase_single(
                     slc_vrt_file=vrt_stack.outfile,
                     output_folder=pl_path,
                     half_window=cfg.phase_linking.half_window.dict(),
-                    strides=cfg.output_options.strides,
+                    strides=strides,
                     reference_idx=0,
                     beta=cfg.phase_linking.beta,
                     mask_file=nodata_mask_file,
@@ -122,7 +126,7 @@ def run(cfg: Workflow, debug: bool = False) -> tuple[list[Path], Path, Path]:
                     amp_dispersion_file=cfg.ps_options._amp_dispersion_file,
                     shp_method=cfg.phase_linking.shp_method,
                     shp_alpha=cfg.phase_linking.shp_alpha,
-                    shp_nslc=None,
+                    shp_nslc=shp_nslc,
                     max_bytes=cfg.worker_settings.block_size_gb * 1e9,
                     n_workers=cfg.worker_settings.n_workers,
                     gpu_enabled=cfg.worker_settings.gpu_enabled,
@@ -134,7 +138,7 @@ def run(cfg: Workflow, debug: bool = False) -> tuple[list[Path], Path, Path]:
                     slc_vrt_file=vrt_stack.outfile,
                     output_folder=pl_path,
                     half_window=cfg.phase_linking.half_window.dict(),
-                    strides=cfg.output_options.strides,
+                    strides=strides,
                     beta=cfg.phase_linking.beta,
                     ministack_size=cfg.phase_linking.ministack_size,
                     mask_file=nodata_mask_file,
@@ -143,7 +147,7 @@ def run(cfg: Workflow, debug: bool = False) -> tuple[list[Path], Path, Path]:
                     amp_dispersion_file=cfg.ps_options._amp_dispersion_file,
                     shp_method=cfg.phase_linking.shp_method,
                     shp_alpha=cfg.phase_linking.shp_alpha,
-                    shp_nslc=None,
+                    shp_nslc=shp_nslc,
                     max_bytes=cfg.worker_settings.block_size_gb * 1e9,
                     n_workers=cfg.worker_settings.n_workers,
                     gpu_enabled=cfg.worker_settings.gpu_enabled,


### PR DESCRIPTION
- Adds a multilooked PS mask file to the saved Workflow outputs
- Adds `bounds` to the workflow config so we can specify exact boundaries, ensuring that missing bursts for a frame don't change the boundary results
- lets the interferogram `Network` accept a sequence of `subdataset`s

This PR closes #102 