### PR TITLE
add tbb to prevent numba crashes

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -20,4 +20,5 @@ dependencies:
   - ruamel.yaml>=0.15
   - scipy>=1.5 # "scipy 0.16+ is required for linear algebra", numba. 1.5 is the oldest version that supports Python 3.7
   - shapely>=1.8
+  - tbb>=2021.6.0 # Module for numba threading which prevents `fork()` crashes
   - threadpoolctl>=3.0

--- a/src/dolphin/workflows/config.py
+++ b/src/dolphin/workflows/config.py
@@ -167,7 +167,7 @@ class UnwrapOptions(BaseModel, extra="forbid"):
     )
     _directory: Path = PrivateAttr(Path("unwrapped"))
     unwrap_method: UnwrapMethod = UnwrapMethod.SNAPHU
-    tiles: list[int] = Field(
+    tiles: List[int] = Field(
         [1, 1],
         description=(
             "Number of tiles to split the unwrapping into (for multi-scale unwrapping)."

--- a/src/dolphin/workflows/config.py
+++ b/src/dolphin/workflows/config.py
@@ -210,7 +210,7 @@ class WorkerSettings(BaseModel, extra="forbid"):
             " for wrapped-phase-estimation."
         ),
     )
-    block_shape: tuple[int, int] = Field(
+    block_shape: Tuple[int, int] = Field(
         (512, 512),
         description="Size (rows, columns) of blocks of data to load at a time.",
     )


### PR DESCRIPTION
- Testing if adding the `tbb` library fixes some of the CI issues.
- also fixing the last two uses of lowercase typing `list/dict/tuple` in `config.py` which pydantic doesn't like in python 3.8.